### PR TITLE
Fixed Small(But Big) Bug

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -45,7 +45,7 @@ const konsolejs = {
         var string = "";
         args.shift();
         args.forEach((el, index) => {
-          string += el;
+          string += el + " ";
         })
         var output = `${this.bindings.cmd.value} <br>${eval(string)}<br>`;
         break;


### PR DESCRIPTION
Forgot to add spaces in
```js
string += el + " ";
```

now it is way more usuable.